### PR TITLE
Update to RaCo v1.3

### DIFF
--- a/G05/G05_main.rca
+++ b/G05/G05_main.rca
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f81dd8d6b52d6d68a148bf315a34d02456ff4ff285a97428dba342e710bdcd87
-size 3113650
+oid sha256:a8e9c460dd529d47d4383b622f7f0df1af2c9bf17e298bd1480c716d25924865
+size 3266396

--- a/G05/README.md
+++ b/G05/README.md
@@ -8,7 +8,7 @@ or send a letter to Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.
 #
 # BMW X5 2018 (G05)
 
-_Created with [Ramses Composer Version 1.0.0](https://github.com/bmwcarit/ramses-composer)_
+_Created with [Ramses Composer Version 1.3.0](https://github.com/bmwcarit/ramses-composer)_
 
 #
 # How to open the project?
@@ -17,8 +17,8 @@ _Created with [Ramses Composer Version 1.0.0](https://github.com/bmwcarit/ramses
 
 Direct links:
 
-* [Windows](https://github.com/bmwcarit/ramses-composer/releases/download/v1.0.0-updated-changelog/RamsesComposerWindows_v1.0.0.zip)
-* [Linux](https://github.com/bmwcarit/ramses-composer/releases/download/v1.0.0-updated-changelog/RamsesComposerLinux_v1.0.0.zip)
+* [Windows](https://github.com/bmwcarit/ramses-composer/releases/download/v1.3.0/RamsesComposerWindows_v1.3.0.zip)
+* [Linux](https://github.com/bmwcarit/ramses-composer/releases/download/v1.3.0/RamsesComposerLinux_v1.3.0.zip)
 
 ## Start the Ramses Composer
 

--- a/G05/_shared/CameraCrane/interfaces/Interface_CameraCrane.lua
+++ b/G05/_shared/CameraCrane/interfaces/Interface_CameraCrane.lua
@@ -1,0 +1,23 @@
+function interface(INOUT)
+    INOUT.AspectFromResolution = Type:Bool()
+    INOUT.CraneGimbal = {
+        Distance = Type:Float(),
+        Pitch = Type:Float(),
+        Roll = Type:Float(),
+        Yaw = Type:Float()
+    }
+    INOUT.Frustum = {
+        AspectRatio = Type:Float(),
+        FarPlane = Type:Float(),
+        HorizontalFOV = Type:Float(),
+        NearPlane = Type:Float()
+    }
+    INOUT.LocalTranslation = Type:Vec3f()
+    INOUT.Origin = Type:Vec3f()
+    INOUT.Viewport = {
+        Height = Type:Int32(),
+        OffsetX = Type:Int32(),
+        OffsetY = Type:Int32(),
+        Width = Type:Int32()
+    }
+end

--- a/G05/_shared/Environment/interfaces/Interface_Environment.lua
+++ b/G05/_shared/Environment/interfaces/Interface_Environment.lua
@@ -1,0 +1,5 @@
+function interface(INOUT)
+    INOUT.ShadowOnGround = Type:Bool()
+    INOUT.ShadowOnGroundColor = Type:Vec3f()
+    INOUT.ShadowOnGroundOpacity = Type:Float()
+end

--- a/G05/interfaces/Interface_Car.lua
+++ b/G05/interfaces/Interface_Car.lua
@@ -1,0 +1,15 @@
+function interface(INOUT)
+    INOUT.CarPaint = {
+        BaseColor = Type:Vec4f(),
+        MetallicRoughness = Type:Vec2f(),
+        Name = Type:String(),
+        NormalScale = Type:Float(),
+        SheenRoughness = Type:Float(),
+        SheenScale = Type:Float()
+    }
+    INOUT.Door_B_L_OpeningValue = Type:Float()
+    INOUT.Door_B_R_OpeningValue = Type:Float()
+    INOUT.Door_F_L_OpeningValue = Type:Float()
+    INOUT.Door_F_R_OpeningValue = Type:Float()
+    INOUT.Tailgate_OpeningValue = Type:Float()
+end


### PR DESCRIPTION
Updates the G05 asset to RaCo version 1.3.

Otherwise, opening the asset with a newer RaCo pollutes the repository with generated interface files.
Found out by following the trace player docs: https://github.com/bmwcarit/ramses-composer-docs/pull/37